### PR TITLE
add simatic ax badge to link the SIMATIC AX github community

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -10,3 +10,4 @@ Click on the badges below to find more Siemens-powered [open source projects](ht
 [![Mendix](https://img.shields.io/badge/github-mendix-0595db?logo=github)](https://github.com/mendix)
 [![MindSphere](https://img.shields.io/badge/github-mindsphere-003751?logo=github)](https://github.com/mindsphere)
 [![TIA Portal](https://img.shields.io/badge/github-tia%20portal-02D8A0?logo=github)](https://github.com/tia-portal-applications)
+[![SIMATIC AX](https://img.shields.io/badge/github-simatic%20ax-00a9bd?logo=github)](https://github.com/simatic-ax)


### PR DESCRIPTION
added a badge for the simatic ax GitHub community URL (https://github.com/simatic-ax)